### PR TITLE
#1816 adapt to new structure of action events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.3
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200528090843-62f0d1c14dab
+	github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83
 )
 
 // replace github.com/keptn/go-utils => ../../keptn/go-utils

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,10 @@ github.com/keptn/go-utils v0.6.3-0.20200528083207-4d4344c6046b h1:FuI8a6LLD2pzPN
 github.com/keptn/go-utils v0.6.3-0.20200528083207-4d4344c6046b/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200528090843-62f0d1c14dab h1:zeEMmBP7mYDlY6O1r+CO6wsD/5m2CIyxUWDSPOSFDug=
 github.com/keptn/go-utils v0.6.3-0.20200528090843-62f0d1c14dab/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200528125316-c4ef2f2f63d9 h1:8wMiCs8trH48Zl8T/p1z1qh8a0JmwyBS2B4UFbXifDk=
+github.com/keptn/go-utils v0.6.3-0.20200528125316-c4ef2f2f63d9/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83 h1:DbyMq5ELazflrYbajEjHlnlVc02qcGqygvayYHhHyDo=
+github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/event_handler/action_triggered_handler_test.go
+++ b/pkg/event_handler/action_triggered_handler_test.go
@@ -147,7 +147,7 @@ func TestActionTriggeredHandler_HandleEvent(t *testing.T) {
       "name": "FeatureToggle",
       "action": "toggle-feature",
       "description": "toggle a feature",
-      "values": {
+      "value": {
         "EnableItemCache": "on"
       }
     },


### PR DESCRIPTION
Since the `values` property of the `action` has been renamed to `value`, and is now an `interface{}` instead of a `map[string]string` in keptn/go-utils,  this change had to be considered in the service.