### PR TITLE
Updated release notes for 0.3.0, updated distributor to 0.8.0, added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.vscode
+
+.idea/*
+# allow shared run configurations
+!.idea/runConfigurations/

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -29,16 +29,16 @@ spec:
                 name: unleash
                 optional: true
         - name: distributor
-          image: keptn/distributor:0.8.0-dev.202102240725 # TODO: change to 0.8.0 once final
+          image: keptn/distributor:0.8.0
           ports:
             - containerPort: 8080
           resources:
             requests:
-              memory: "32Mi"
-              cpu: "50m"
+              memory: "16Mi"
+              cpu: "25m"
             limits:
-              memory: "128Mi"
-              cpu: "500m"
+              memory: "32Mi"
+              cpu: "250m"
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'

--- a/releasenotes/releasenotes_V0.3.0.md
+++ b/releasenotes/releasenotes_V0.3.0.md
@@ -2,8 +2,9 @@
 
 ## New Features
 
+- Use CloudEvents 1.0 [#20](https://github.com/keptn-contrib/unleash-service/issues/20)
+- Move Build and Tests from Travis-CI to GH Actions [#24](https://github.com/keptn-contrib/unleash-service/issues/24)
+
 ## Fixed Issues
 
-- Update to CloudEvents 1.0 [#20](https://github.com/keptn-contrib/unleash-service/issues/20)
-
-## Known Limitations
+- Updated Example in README with correct Namespace [#22](https://github.com/keptn-contrib/unleash-service/pull/22)


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR updates release notes for 0.3.0 (based on 0.3.0-alpha), updates the keptn distributor to 0.8.0, and adds a .gitignore