### PR TITLE
feat: Do not return errors from eventhandler

### DIFF
--- a/pkg/event_handler/action_triggered_handler.go
+++ b/pkg/event_handler/action_triggered_handler.go
@@ -28,7 +28,7 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 	err := eh.Event.DataAs(actionTriggeredEvent)
 	if err != nil {
 		eh.Logger.Error("feature toggle remediation action not well formed: " + err.Error())
-		return errors.New("feature toggle remediation action not well formed: " + err.Error())
+		return nil
 	}
 
 	if actionTriggeredEvent.Action.Action != ActionToggleFeature {
@@ -49,7 +49,6 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 		eh.Logger.Error(msg)
 		err = eh.sendEvent(keptnv2.GetFinishedEventType(keptnv2.ActionTaskName),
 			eh.getActionFinishedEvent(keptnv2.ResultFailed, keptnv2.StatusErrored, *actionTriggeredEvent, msg))
-		return errors.New(msg)
 	}
 
 	for feature, value := range values {
@@ -62,7 +61,7 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 				eh.Logger.Error("could not send action-finished event: " + err.Error())
 				return err
 			}
-			return errors.New("Value property of feature toggle remediation action not valid. It must be set: TOGGLENAME:\"on\" or TOGGLENAME:\"off\"")
+			return nil
 		}
 		err = toggleFeature(feature, value.(string))
 		if err != nil {
@@ -74,7 +73,7 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 				eh.Logger.Error("could not send action-finished event: " + err.Error())
 				return err
 			}
-			return err
+			return nil
 		}
 	}
 

--- a/pkg/event_handler/action_triggered_handler.go
+++ b/pkg/event_handler/action_triggered_handler.go
@@ -49,6 +49,9 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 		eh.Logger.Error(msg)
 		err = eh.sendEvent(keptnv2.GetFinishedEventType(keptnv2.ActionTaskName),
 			eh.getActionFinishedEvent(keptnv2.ResultFailed, keptnv2.StatusErrored, *actionTriggeredEvent, msg))
+		if err != nil {
+			return fmt.Errorf("%s: %w", msg, err)
+		}
 		return nil
 	}
 

--- a/pkg/event_handler/action_triggered_handler.go
+++ b/pkg/event_handler/action_triggered_handler.go
@@ -28,7 +28,7 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 	err := eh.Event.DataAs(actionTriggeredEvent)
 	if err != nil {
 		eh.Logger.Error("feature toggle remediation action not well formed: " + err.Error())
-		return nil
+		return errors.New("feature toggle remediation action not well formed: " + err.Error())
 	}
 
 	if actionTriggeredEvent.Action.Action != ActionToggleFeature {
@@ -49,6 +49,7 @@ func (eh ActionTriggeredHandler) HandleEvent() error {
 		eh.Logger.Error(msg)
 		err = eh.sendEvent(keptnv2.GetFinishedEventType(keptnv2.ActionTaskName),
 			eh.getActionFinishedEvent(keptnv2.ResultFailed, keptnv2.StatusErrored, *actionTriggeredEvent, msg))
+		return nil
 	}
 
 	for feature, value := range values {


### PR DESCRIPTION
## This PR

- Do not return errors from event handler that are already sent in the `action.finished` event

Fixes: #76 