### PR TITLE
docs: Added example for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ It is recommended to make use of branches as follows:
 
 When writing code, it is recommended to follow the coding style suggested by the [Golang community](https://github.com/golang/go/wiki/CodeReviewComments).
 
+To manually verify your changes, please follow the guide in the [example/ folder](example).
+
 ### How to release a new version of this service
 
 It is assumed that the current development takes place in the `main` branch (either via Pull Requests or directly).

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,10 @@
+# How to manually test unleash-service
+
+1. Install and configure Unleash (out of scope here)
+2. Install unleash-service (see [Installation instructions](../README.md#Installation))
+3. Configure unleash-service to connect to Unleash: `kubectl -n keptn create secret generic unleash --from-literal="UNLEASH_SERVER_URL=http://unleash.unleash-dev/api" --from-literal="UNLEASH_USER=keptn" --from-literal="UNLEASH_TOKEN=keptn"`
+4. Create your Keptn project with a stage `production` and a sequence `remediation`: `keptn create project sockshop --shipyard=shiypard.yaml`
+5. Create a service: `keptn create service carts --project sockshop`
+6. Add remediation.yaml to your project: `keptn add-resource --project sockshop --service carts --stage production --resourceUri remediation.yaml`
+7. Trigger remediation using CLI: `keptn send event -f remediation_trigger.json`
+8. Watch :)

--- a/example/README.md
+++ b/example/README.md
@@ -2,9 +2,9 @@
 
 1. Install and configure Unleash (out of scope here)
 2. Install unleash-service (see [Installation instructions](../README.md#Installation))
-3. Configure unleash-service to connect to Unleash: `kubectl -n keptn create secret generic unleash --from-literal="UNLEASH_SERVER_URL=http://unleash.unleash-dev/api" --from-literal="UNLEASH_USER=keptn" --from-literal="UNLEASH_TOKEN=keptn"`
-4. Create your Keptn project with a stage `production` and a sequence `remediation`: `keptn create project sockshop --shipyard=shiypard.yaml`
+3. Create Kubernetes secret for unleash-service to connect to Unleash: `kubectl -n keptn create secret generic unleash --from-literal="UNLEASH_SERVER_URL=http://unleash.unleash-dev/api" --from-literal="UNLEASH_USER=keptn" --from-literal="UNLEASH_TOKEN=keptn"`
+4. Create your Keptn project with a stage `production` and a sequence `remediation`: `keptn create project sockshop --shipyard=shipyard.yaml`
 5. Create a service: `keptn create service carts --project sockshop`
-6. Add remediation.yaml to your project: `keptn add-resource --project sockshop --service carts --stage production --resourceUri remediation.yaml`
-7. Trigger remediation using CLI: `keptn send event -f remediation_trigger.json`
+6. Add remediation.yaml to your project: `keptn add-resource --project sockshop --service carts --stage production --resource remediation.yaml --resourceUri remediation.yaml`
+7. Trigger remediation using CLI: `keptn send event -f remediation-triggered.json`
 8. Watch :)

--- a/example/remediation-triggered.json
+++ b/example/remediation-triggered.json
@@ -1,0 +1,17 @@
+{
+  "type": "sh.keptn.event.production.remediation.triggered",
+  "specversion": "1.0",
+  "source": "https:\/\/github.com\/keptn-contrib\/prometheus-service",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d",
+  "time": "2019-06-07T07:02:15.64489Z",
+  "contenttype": "application\/json",
+  "data": {
+    "project": "sockshop",
+    "stage": "production",
+    "service": "carts",
+    "problem": {
+      "problemTitle": "failure_rate_increase",
+      "rootCause": "Failure rate increase"
+    }
+  }
+}

--- a/example/remediation.yaml
+++ b/example/remediation.yaml
@@ -1,0 +1,13 @@
+apiVersion: spec.keptn.sh/0.1.4
+kind: Remediation
+metadata:
+  name: carts-remediation
+spec:
+  remediations:
+    - problemType: Failure rate increase
+      actionsOnOpen:
+        - action: toggle-feature
+          name: Toogle feature flag
+          description: Toogle feature flag EnablePromotion to OFF
+          value:
+            EnablePromotion: "off"

--- a/example/shipyard.yaml
+++ b/example/shipyard.yaml
@@ -1,0 +1,21 @@
+apiVersion: "spec.keptn.sh/0.2.2"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-sockshop"
+spec:
+  stages:
+    - name: "production"
+      sequences:
+        - name: "remediation"
+          triggeredOn:
+            - event: "production.remediation.finished"
+              selector:
+                match:
+                  evaluation.result: "fail"
+          tasks:
+            - name: "get-action"
+            - name: "action"
+            - name: "evaluation"
+              triggeredAfter: "3m"
+              properties:
+                timeframe: "3m"


### PR DESCRIPTION
Added a quick guide on how to manually test unleash-service.
For installing and configuring unleash, I'd like to refer to the [Full Tour on Dynatrace tutorial](https://tutorials.keptn.sh/tutorials/keptn-full-tour-dynatrace-011/index.html?index=..%2F..index#25). But as tutorials constantly changes, I am not willing to add a link.