### PR TITLE
feat: Remove cluster admin permissions

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "keptn-service.name" -}}
+{{- define "unleash-service.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "keptn-service.fullname" -}}
+{{- define "unleash-service.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "keptn-service.chart" -}}
+{{- define "unleash-service.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "keptn-service.labels" -}}
-helm.sh/chart: {{ include "keptn-service.chart" . }}
-{{ include "keptn-service.selectorLabels" . }}
+{{- define "unleash-service.labels" -}}
+helm.sh/chart: {{ include "unleash-service.chart" . }}
+{{ include "unleash-service.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,17 +46,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "keptn-service.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "keptn-service.name" . }}
+{{- define "unleash-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unleash-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "keptn-service.serviceAccountName" -}}
+{{- define "unleash-service.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "keptn-service.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "unleash-service.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,15 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "keptn-service.fullname" . }}
+  name: {{ include "unleash-service.fullname" . }}
   labels:
-    {{- include "keptn-service.labels" . | nindent 4 }}
+    {{- include "unleash-service.labels" . | nindent 4 }}
 
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "keptn-service.selectorLabels" . | nindent 6 }}
+      {{- include "unleash-service.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -17,13 +17,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "keptn-service.labels" . | nindent 8 }}
+        {{- include "unleash-service.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "keptn-service.serviceAccountName" . }}
+      serviceAccountName: {{ include "unleash-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "keptn-service.fullname" . }}
+  name: {{ include "unleash-service.fullname" . }}
   labels:
-    {{- include "keptn-service.labels" . | nindent 4 }}
+    {{- include "unleash-service.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
   selector:
-    {{- include "keptn-service.selectorLabels" . | nindent 4 }}
+    {{- include "unleash-service.selectorLabels" . | nindent 4 }}
   {{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,30 +1,55 @@
+  {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "keptn-service.serviceAccountName" . }}
+  name: {{ include "unleash-service.serviceAccountName" . }}
   labels:
-    {{- include "keptn-service.labels" . | nindent 4 }}
+    {{- include "unleash-service.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: unleash-service
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: keptn-unleash-service
-  labels:
-    {{- include "keptn-service.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+  name: unleash-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: unleash-service
 subjects:
   - kind: ServiceAccount
-    name: {{ include "keptn-service.serviceAccountName" . }}
+    name: {{ include "unleash-service.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
-  apiGroup: rbac.authorization.k8s.io
+    {{- end }}

--- a/chart/templates/tests/test-api-connection.yaml
+++ b/chart/templates/tests/test-api-connection.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "keptn-service.fullname" . }}-test-api-connection"
+  name: "{{ include "unleash-service.fullname" . }}-test-api-connection"
   labels:
-  {{- include "keptn-service.labels" . | nindent 4 }}
+  {{- include "unleash-service.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
 spec:


### PR DESCRIPTION
## This PR

- Removes cluster-admin permissions
- Create a new `ClusterRole` with needed permissions
- Refactor service name in Helm chart

Fixes: #75 