### PR TITLE
feat: Filter events to avoid stuck sequence

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"log"
 	"os"
 
@@ -28,7 +29,18 @@ func main() {
 		serviceName,
 		sdk.WithTaskHandler(
 			getActionTriggeredEventType,
-			event_handler.NewActionTriggeredHandler()),
+			event_handler.NewActionTriggeredHandler(),
+			actionTriggeredFilter),
 		sdk.WithLogger(logrus.New()),
 	).Start())
+}
+
+func actionTriggeredFilter(keptnHandle sdk.IKeptn, event sdk.KeptnEvent) bool {
+	data := &keptnv2.ActionTriggeredEventData{}
+	if err := keptnv2.Decode(event.Data, data); err != nil {
+		keptnHandle.Logger().Errorf("Could not parse test.triggered event: %s", err.Error())
+		return false
+	}
+
+	return data.Action.Action == event_handler.ActionToggleFeature
 }

--- a/pkg/event_handler/action_triggered_handler.go
+++ b/pkg/event_handler/action_triggered_handler.go
@@ -28,11 +28,6 @@ func (eh *ActionTriggeredHandler) Execute(k sdk.IKeptn, event sdk.KeptnEvent) (i
 		return nil, &sdk.Error{Err: err, StatusType: keptnv2.StatusErrored, ResultType: keptnv2.ResultFailed, Message: "failed to decode action.triggered event: " + err.Error()}
 	}
 
-	if actionTriggeredEvent.Action.Action != ActionToggleFeature {
-		k.Logger().Infof("Received action %s does not match supported action %s. Skipping this action.", actionTriggeredEvent.Action.Action, ActionToggleFeature)
-		return nil, nil
-	}
-
 	values, ok := actionTriggeredEvent.Action.Value.(map[string]interface{})
 
 	if !ok {


### PR DESCRIPTION
Currently, the `unleash-service` returns an empty response when the action is unequal to `toggle-feature` which tells the `go-sdk` not to send a finished event. This produces a stuck sequence since the `go-sdk` automatically sends a started event, but no finished event is sent.

 To avoid this, we can filter the event beforehand so no started event is sent.

## This PR

- Filters `action.triggered` events so that the action needs to equal `toggle-feature`