### PR TITLE
Perf: Removed CONFIGURATION_SERVICES  (#92)

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
           ports:
             - containerPort: 80
           env:
-          - name: CONFIGURATION_SERVICE
-            value: "http://localhost:8081/configuration-service"
           - name: env
             value: 'production'
           - name: PUBSUB_TOPIC


### PR DESCRIPTION
As Unleash-services uses Go-sdk we dont need CONFIGURATION_SERVICE env variable.

Signed-off-by: Tarang Verma <tarangverma004@gmail.com>